### PR TITLE
docs: Resolve indentation on README codeblocks and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ response = huggingface.ChatCompletion.create(
         {"role": "system", "content": "\nYou are a helpful assistant speaking like a pirate. argh!"},
         {"role": "user", "content": "What is the sun?"},
     ],
-      temperature=0.9,
-      top_p=0.6,
-      max_tokens=256,
+    temperature=0.9,
+    top_p=0.6,
+    max_tokens=256,
 )
 
 print(response)
@@ -84,20 +84,20 @@ See the [documentation](https://philschmid.github.io/easyllm/) for more detailed
 Migrating from OpenAI to HuggingFace is easy. Just change the import statement and the client you want to use and optionally the prompt builder.
 
 ```diff
--import openai
+- import openai
 + from easyllm.clients import huggingface
 + huggingface.prompt_builder = build_llama2_prompt
 
 
--response = openai.ChatCompletion.create(
-+response = huggingface.ChatCompletion.create(
--    model="gpt-3.5-turbo",
-+    model="meta-llama/Llama-2-70b-chat-hf",
-    messages=[
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "Knock knock."},
-    ],
-)
+- response = openai.ChatCompletion.create(
++ response = huggingface.ChatCompletion.create(
+-     model="gpt-3.5-turbo",
++     model="meta-llama/Llama-2-70b-chat-hf",
+      messages=[
+          {"role": "system", "content": "You are a helpful assistant."},
+          {"role": "user", "content": "Knock knock."},
+      ],
+  )
 ```
 
 Make sure when you switch your client that your hyperparameters are still valid. For example, `temperature` of GPT-3 might be different than `temperature` of `Llama-2`.

--- a/docs/prompt_utils.md
+++ b/docs/prompt_utils.md
@@ -1,6 +1,6 @@
 # Prompt utilities
 
-The `prompt_utils`  module contains functions to assist with converting Message's Dictonaries into prompts that can be used with `ChatCompletion` clients. 
+The `prompt_utils`  module contains functions to assist with converting Message's Dictionaries into prompts that can be used with `ChatCompletion` clients. 
 
 ## Llama 2 Chat builder 
 

--- a/easyllm/clients/huggingface.py
+++ b/easyllm/clients/huggingface.py
@@ -171,7 +171,7 @@ You can also use existing prompt builders by importing them from easyllm.prompt_
                 generated_tokens += res.details.generated_tokens
                 choices.append(parsed)
                 logger.debug(f"Response at index {_i}:\n{parsed}")
-            # calcuate usage details
+            # calculate usage details
             # TODO: fix when details is fixed
             prompt_tokens = int(len(prompt) / 4)
             total_tokens = prompt_tokens + generated_tokens


### PR DESCRIPTION
Hello!

## Pull Request overview
* Resolve indentation issues on the README.
* Resolve typos

## Details
The indentation of two snippets in the README were a bit off. In particular, the temperature etc. arguments were misaligned with the arguments above. Additionally, for `diff` codeblocks the general wisdom is to offset the entire codeblock by two spaces so each line is still aligned nicely relative to the others, regardless of what color they are.
Both snippets should be properly indented with 4 spaces now.

Looking forward to giving this a try some more later.

- Tom Aarsen