### PR TITLE
docs: typos & slight documentation improvements

### DIFF
--- a/docs/clients/huggingface.md
+++ b/docs/clients/huggingface.md
@@ -1,6 +1,6 @@
 # Hugging Face 
 
-Easyllm provides a client for interfacing with HuggingFace models. The client is compatible with the [HuggingFace Inference API](https://huggingface.co/docs/api-inference/index), [Hugging Face Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index) or any Web Service running [Text Generation Inference](https://github.com/huggingface/text-generation-inference) or compatible API endpoints. 
+EasyLLM provides a client for interfacing with HuggingFace models. The client is compatible with the [HuggingFace Inference API](https://huggingface.co/docs/api-inference/index), [Hugging Face Inference Endpoints](https://huggingface.co/docs/inference-endpoints/index) or any Web Service running [Text Generation Inference](https://github.com/huggingface/text-generation-inference) or compatible API endpoints. 
 
 - `huggingface.ChatCompletion` - a client for interfacing with HuggingFace models that are compatible with the OpenAI ChatCompletion API.
 - `huggingface.Completion` - a client for interfacing with HuggingFace models that are compatible with the OpenAI Completion API.

--- a/docs/clients/huggingface.md
+++ b/docs/clients/huggingface.md
@@ -8,7 +8,7 @@ Easyllm provides a client for interfacing with HuggingFace models. The client is
 
 ## `huggingface.ChatCompletion`
 
-The `huggingface.ChatCompletion` client is used to interface with HuggingFace models running on Text Generation infernece that are compatible with the OpenAI ChatCompletion API. Checkout the [Examples](../examples/chat-completion-api) for more details and [How to stream completions](../examples/stream-chat-completion-api) for an example how to stream requests.
+The `huggingface.ChatCompletion` client is used to interface with HuggingFace models running on Text Generation inference that are compatible with the OpenAI ChatCompletion API. Checkout the [Examples](../examples/chat-completion-api) for more details and [How to stream completions](../examples/stream-chat-completion-api) for an example how to stream requests.
 
 
 ```python
@@ -48,7 +48,7 @@ Supported parameters are:
 
 ## `huggingface.Completion`
 
-The `huggingface.Completion` client is used to interface with HuggingFace models running on Text Generation infernece that are compatible with the OpenAI Completion API. Checkout the [Examples](../examples/text-completion-api) for more details and [How to stream completions](../examples/stream-text-completion-api) for an example how to stream requests.
+The `huggingface.Completion` client is used to interface with HuggingFace models running on Text Generation inference that are compatible with the OpenAI Completion API. Checkout the [Examples](../examples/text-completion-api) for more details and [How to stream completions](../examples/stream-text-completion-api) for an example how to stream requests.
 
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,7 @@ the result will look like
 ```
 
 Check out other examples:
+
 * [Detailed ChatCompletion Example](examples/chat-completion-api)
 * [Example how to stream chat requests](examples/stream-chat-completion)
 * [Example how to stream text requests](examples/stream-text-completion)

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,9 +32,9 @@ response = huggingface.ChatCompletion.create(
         {"role": "system", "content": "\nYou are a helpful assistant speaking like a pirate. argh!"},
         {"role": "user", "content": "What is the sun?"},
     ],
-      temperature=0.9,
-      top_p=0.6,
-      max_tokens=256,
+    temperature=0.9,
+    top_p=0.6,
+    max_tokens=256,
 )
 
 print(response)

--- a/notebooks/chat-completion-api.ipynb
+++ b/notebooks/chat-completion-api.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# How to use Chat Completion clients\n",
     "\n",
-    "Easyllm can be used as an abstract layer to replace `gpt-3.5-turbo` and `gpt-4` with open source models.\n",
+    "EasyLLM can be used as an abstract layer to replace `gpt-3.5-turbo` and `gpt-4` with open source models.\n",
     "\n",
     "You can change your own applications from the OpenAI API, by simply changing the client. \n",
     "\n",

--- a/notebooks/text-completion-api.ipynb
+++ b/notebooks/text-completion-api.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# # How to use Text (Instruction) Completion clients\n",
     "\n",
-    "Easyllm can be used as an abstract layer to replace `text-davinci-003` with open source models.\n",
+    "EasyLLM can be used as an abstract layer to replace `text-davinci-003` with open source models.\n",
     "\n",
     "You can change your own applications from the OpenAI API, by simply changing the client. \n",
     "\n",


### PR DESCRIPTION
Hello!

## Pull Request overview
* 2 small typos: 'infernece' -> 'inference'
* Docstring indentation
* Doc builder needs a space before a list
* Easyllm -> EasyLLM

## Details
These should speak for themselves.

- Tom Aarsen