### PR TITLE
Fix/Makes `model` parameter optional

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -4,12 +4,13 @@ Here are some examples to help you get started with the easyllm library:
 
 ## Hugging Face
 
-| Example                                                        | Description                                                                           |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| [Detailed ChatCompletion Example](chat-completion-api)         | Shows how to use the ChatCompletion API to have a conversational chat with the model. |
-| [Example how to stream chat requests](stream-chat-completions) | Demonstrates streaming multiple chat requests to efficiently chat with the model.     |
-| [Example how to stream text requests](stream-text-completions) | Shows how to stream multiple text completion requests.                                |
-| [Detailed Completion Example](text-completion-api)             | Uses the TextCompletion API to generate text with the model.                          |
-| [Create Embeddings](get-embeddings)                            | Embeds text into vector representations using the model.                              |
+| Example                                                                 | Description                                                                           |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [Detailed ChatCompletion Example](chat-completion-api)                  | Shows how to use the ChatCompletion API to have a conversational chat with the model. |
+| [Example how to stream chat requests](stream-chat-completions)          | Demonstrates streaming multiple chat requests to efficiently chat with the model.     |
+| [Example how to stream text requests](stream-text-completions)          | Shows how to stream multiple text completion requests.                                |
+| [Detailed Completion Example](text-completion-api)                      | Uses the TextCompletion API to generate text with the model.                          |
+| [Create Embeddings](get-embeddings)                                     | Embeds text into vector representations using the model.                              |
+| [Hugging Face Inference Endpoints Example](inference-endpoints-example) | Example on how to use custom endpoints, e.g. Inference Endpoints or localhost.        |
 
 The examples cover the main functionality of the library - chat, text completion, and embeddings. Let me know if you would like me to modify or expand the index page in any way.

--- a/easyllm/clients/huggingface.py
+++ b/easyllm/clients/huggingface.py
@@ -114,6 +114,8 @@ You can also use existing prompt builders by importing them from easyllm.prompt_
         if r.model:
             url = f"{api_base}/{r.model}"
             logger.debug(f"Url:\n{url}")
+        else:
+            url = api_base
 
         # create the client
         client = InferenceClient(url, token=api_key)
@@ -259,6 +261,8 @@ You can also use existing prompt builders by importing them from easyllm.prompt_
         if r.model:
             url = f"{api_base}/{r.model}"
             logger.debug(f"Url:\n{url}")
+        else:
+            url = api_base
 
         # create the client
         client = InferenceClient(url, token=api_key)
@@ -366,6 +370,8 @@ class Embedding:
             else:
                 url = f"{api_base}/{r.model}"
             logger.debug(f"Url:\n{url}")
+        else:
+            url = api_base
 
         # create the client
         client = InferenceClient(url, token=api_key)

--- a/easyllm/schema/openai.py
+++ b/easyllm/schema/openai.py
@@ -33,7 +33,7 @@ class ChatCompletionResponse(BaseModel):
     id: str = Field(default_factory=lambda: f"hf-{generate(size=10)}")
     object: str = "chat.completion"
     created: int = Field(default_factory=lambda: int(time.time()))
-    model: str
+    model: Optional[str] = "custom"
     choices: List[ChatCompletionResponseChoice]
     usage: Usage
 
@@ -53,12 +53,12 @@ class ChatCompletionStreamResponse(BaseModel):
     id: str = Field(default_factory=lambda: f"hf-{generate(size=10)}")
     object: str = "chat.completion.chunk"
     created: int = Field(default_factory=lambda: int(time.time()))
-    model: str
+    model: Optional[str] = None
     choices: List[ChatCompletionResponseStreamChoice]
 
 
 class CompletionRequest(BaseModel):
-    model: str
+    model: Optional[str] = None
     prompt: Union[str, List[Any]]
     suffix: Optional[str] = None
     temperature: Optional[float] = 0.9
@@ -86,7 +86,7 @@ class CompletionResponse(BaseModel):
     id: str = Field(default_factory=lambda: f"hf-{generate(size=10)}")
     object: str = "text.completion"
     created: int = Field(default_factory=lambda: int(time.time()))
-    model: str
+    model: Optional[str] = "custom"
     choices: List[CompletionResponseChoice]
     usage: Usage
 
@@ -102,7 +102,7 @@ class CompletionStreamResponse(BaseModel):
     id: str = Field(default_factory=lambda: f"hf-{generate(size=10)}")
     object: str = "text.completion"
     created: int = Field(default_factory=lambda: int(time.time()))
-    model: str
+    model: Optional[str] = "custom"
     choices: List[CompletionResponseStreamChoice]
 
 
@@ -121,5 +121,5 @@ class EmbeddingsObjectResponse(BaseModel):
 class EmbeddingsResponse(BaseModel):
     object: str = "list"
     data: List[EmbeddingsObjectResponse]
-    model: str
+    model: Optional[str] = "custom"
     usage: Usage

--- a/notebooks/inference-endpoints-example.ipynb
+++ b/notebooks/inference-endpoints-example.ipynb
@@ -1,0 +1,234 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Hugging Face Inference Endpoints Example\n",
+    "\n",
+    "**[Hugging Face Inference Endpoints](https://ui.endpoints.huggingface.co/)** offers an easy and secure way to deploy Machine Learning models for use in production. Inference Endpoints empower developers and data scientists alike to create AI applications without managing infrastructure: simplifying the deployment process to a few clicks, including handling large volumes of requests with autoscaling, reducing infrastructure costs with scale-to-zero, and offering advanced security.\n",
+    "\n",
+    "You can get started with Inference Endpoints at: https://ui.endpoints.huggingface.co/\n",
+    "\n",
+    "\n",
+    "The example assumes that you have an running endpoint for a conversational model, e.g. `https://huggingface.co/meta-llama/Llama-2-13b-chat-hf`"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Import the easyllm library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if needed, install and/or upgrade to the latest version of the OpenAI Python library\n",
+    "%pip install --upgrade easyllm "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. An example chat API call\n",
+    "\n",
+    "Since we want to use our endpoint for inference we don't have to define the `model` parameter. We either need to expose an environment variable `HUGGINGFACE_API_BASE` before the import of `easyllm.clients.huggingface` or overwrite the `huggingface.api_base` value.\n",
+    "\n",
+    "A chat API call then only has two required inputs:\n",
+    "- `messages`: a list of message objects, where each object has two required fields:\n",
+    "    - `role`: the role of the messenger (either `system`, `user`, or `assistant`)\n",
+    "    - `content`: the content of the message (e.g., `Write me a beautiful poem`)\n",
+    "\n",
+    "Let's look at an example chat API calls to see how the chat format works in practice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'hf-0lL5H_yyRR',\n",
+       " 'object': 'chat.completion',\n",
+       " 'created': 1691096023,\n",
+       " 'choices': [{'index': 0,\n",
+       "   'message': {'role': 'assistant', 'content': ' Apple who?'},\n",
+       "   'finish_reason': 'eos_token'}],\n",
+       " 'usage': {'prompt_tokens': 149, 'completion_tokens': 5, 'total_tokens': 154}}"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from easyllm.clients import huggingface\n",
+    "from easyllm.prompt_utils import llama2_stop_sequences, build_llama2_prompt\n",
+    "\n",
+    "huggingface.prompt_builder = build_llama2_prompt\n",
+    "\n",
+    "# Here you can overwrite the url to your endpoint, can also be localhost:8000\n",
+    "huggingface.api_base = \"YOUR_ENDPOINT_URL\"\n",
+    "\n",
+    "# The module automatically loads the HuggingFace API key from the environment variable HUGGINGFACE_TOKEN or from the HuggingFace CLI configuration file.\n",
+    "# huggingface.api_key=\"hf_xxx\"\n",
+    "\n",
+    "response = huggingface.ChatCompletion.create(\n",
+    "    messages=[\n",
+    "        {\"role\": \"system\", \"content\": \"\\nYou are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe.  Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature.\\n\\nIf a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information.\"},\n",
+    "        {\"role\": \"user\", \"content\": \"Knock knock.\"},\n",
+    "        {\"role\": \"assistant\", \"content\": \"Who's there?\"},\n",
+    "        {\"role\": \"user\", \"content\": \"Apple.\"},\n",
+    "    ],\n",
+    "      temperature=0.9,\n",
+    "      top_p=0.6,\n",
+    "      max_tokens=1024,\n",
+    ")\n",
+    "response"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see, the response object has a few fields:\n",
+    "- `id`: the ID of the request\n",
+    "- `object`: the type of object returned (e.g., `chat.completion`)\n",
+    "- `created`: the timestamp of the request\n",
+    "- `model`: the full name of the model used to generate the response\n",
+    "- `usage`: the number of tokens used to generate the replies, counting prompt, completion, and total\n",
+    "- `choices`: a list of completion objects (only one, unless you set `n` greater than 1)\n",
+    "    - `message`: the message object generated by the model, with `role` and `content`\n",
+    "    - `finish_reason`: the reason the model stopped generating text (either `stop`, or `length` if `max_tokens` limit was reached)\n",
+    "    - `index`: the index of the completion in the list of choices"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Extract just the reply with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Apple who?\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response['choices'][0]['message']['content'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How to stream Chat Completion requests\n",
+    "\n",
+    "Custom endpoints can be created to stream chat completion requests to a model. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sure! Here we go:\n",
+      "\n",
+      "1. One\n",
+      "2. Two\n",
+      "3. Three\n",
+      "4. Four\n",
+      "5. Five\n",
+      "6. Six\n",
+      "7. Seven\n",
+      "8. Eight\n",
+      "9. Nine\n",
+      "10. Ten!"
+     ]
+    }
+   ],
+   "source": [
+    "from easyllm.clients import huggingface\n",
+    "from easyllm.prompt_utils import llama2_stop_sequences, build_llama2_prompt\n",
+    "\n",
+    "huggingface.prompt_builder = build_llama2_prompt\n",
+    "\n",
+    "# Here you can overwrite the url to your endpoint, can also be localhost:8000\n",
+    "huggingface.api_base = \"YOUR_ENDPOINT_URL\"\n",
+    "\n",
+    "# a ChatCompletion request\n",
+    "response = huggingface.ChatCompletion.create(\n",
+    "    messages=[\n",
+    "        {'role': 'user', 'content': \"Count to 10.\"}\n",
+    "    ],\n",
+    "    stream=True  # this time, we set stream=True\n",
+    ")\n",
+    "\n",
+    "for chunk in response:\n",
+    "    delta = chunk['choices'][0]['delta']\n",
+    "    if \"content\" in delta:\n",
+    "        print(delta[\"content\"],end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "openai",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "365536dcbde60510dc9073d6b991cd35db2d9bac356a11f5b64279a5e6708b97"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Also adds an example for how to use a custom endpoint, e.g. inference endpoints 


close #11 