### PR TITLE
Fix prompt builder inputs

### DIFF
--- a/docs/prompt_utils.md
+++ b/docs/prompt_utils.md
@@ -4,12 +4,16 @@ The `prompt_utils`  module contains functions to assist with converting Message'
 
 Supported prompt formats:
 
-* [Llama 2](#llama-2-chat-builder)
-* [Vicuna](#vicuna-chat-builder)
-* [Hugging Face ChatML](#hugging-face-chatml-builder)
-* [WizardLM](#wizardlm-chat-builder)
-* [StableBeluga2](#stablebeluga2-chat-builder)
-* [Open Assistant](#open-assistant-chat-builder)
+- [Prompt utilities](#prompt-utilities)
+  - [Set prompt builder for client](#set-prompt-builder-for-client)
+  - [Llama 2 Chat builder](#llama-2-chat-builder)
+  - [Vicuna Chat builder](#vicuna-chat-builder)
+  - [Hugging Face ChatML builder](#hugging-face-chatml-builder)
+    - [StarChat](#starchat)
+    - [Falcon](#falcon)
+  - [WizardLM Chat builder](#wizardlm-chat-builder)
+  - [StableBeluga2 Chat builder](#stablebeluga2-chat-builder)
+  - [Open Assistant Chat builder](#open-assistant-chat-builder)
 
 Prompt utils are also exporting a mapping dictionary `PROMPT_MAPPING` that maps a model name to a prompt builder function. This can be used to select the correct prompt builder function via an environment variable. 
 
@@ -42,11 +46,13 @@ Example Models:
 * [meta-llama/Llama-2-70b-chat-hf](https://huggingface.co/meta-llama/Llama-2-70b-chat-hf)
 
 ```python
+from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_llama2_prompt
 
+
 messages=[
-    {"role": "system", "content": "You are a helpful assistant."},
-    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
+    ChatMessage(role="system", content="You are a helpful assistant."),
+    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
 ]
 prompt = build_llama2_prompt(messages)
 ```
@@ -62,11 +68,12 @@ Example Models:
 
 
 ```python
+from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_vicuna_prompt
 
 messages=[
-    {"role": "system", "content": "You are a helpful assistant."},
-    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
+    ChatMessage(role="system", content="You are a helpful assistant."),
+    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
 ]
 prompt = build_vicuna_prompt(messages)
 ```
@@ -81,11 +88,12 @@ Example Models:
 ### StarChat
 
 ```python
+from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_chatml_starchat_prompt
 
 messages=[
-    {"role": "system", "content": "You are a helpful assistant."},
-    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
+    ChatMessage(role="system", content="You are a helpful assistant."),
+    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
 ]
 prompt = build_chatml_starchat_prompt(messages)
 ```
@@ -93,11 +101,12 @@ prompt = build_chatml_starchat_prompt(messages)
 ### Falcon
 
 ```python
+from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_chatml_falcon_prompt
 
 messages=[
-    {"role": "system", "content": "You are a helpful assistant."},
-    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
+    ChatMessage(role="system", content="You are a helpful assistant."),
+    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
 ]
 prompt = build_chatml_falcon_prompt(messages)
 ```
@@ -111,11 +120,12 @@ Example Models:
 * [WizardLM/WizardLM-13B-V1.2](https://huggingface.co/WizardLM/WizardLM-13B-V1.2)
 
 ```python
+from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_wizardlm_prompt
 
 messages=[
-    {"role": "system", "content": "You are a helpful assistant."},
-    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
+    ChatMessage(role="system", content="You are a helpful assistant."),
+    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
 ]
 prompt = build_wizardlm_prompt(messages)
 ```
@@ -125,11 +135,12 @@ prompt = build_wizardlm_prompt(messages)
 Creates StableBeluga2 prompt for a chat conversation. If a `Message` with an unsupported `role` is passed, an error will be thrown. [Reference](https://huggingface.co/stabilityai/StableBeluga2)
 
 ```python
+from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_stablebeluga_prompt
 
 messages=[
-    {"role": "system", "content": "You are a helpful assistant."},
-    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
+    ChatMessage(role="system", content="You are a helpful assistant."),
+    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
 ]
 prompt = build_stablebeluga_prompt(messages)
 ```
@@ -143,11 +154,12 @@ Example Models:
 * [OpenAssistant/llama2-13b-orca-8k-3319](https://huggingface.co/OpenAssistant/llama2-13b-orca-8k-33192)
 
 ```python
+from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_open_assistant_prompt
 
 messages=[
-    {"role": "system", "content": "You are a helpful assistant."},
-    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
+    ChatMessage(role="system", content="You are a helpful assistant."),
+    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
 ]
 prompt = build_open_assistant_prompt(messages)
 ```

--- a/docs/prompt_utils.md
+++ b/docs/prompt_utils.md
@@ -42,13 +42,11 @@ Example Models:
 * [meta-llama/Llama-2-70b-chat-hf](https://huggingface.co/meta-llama/Llama-2-70b-chat-hf)
 
 ```python
-from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_llama2_prompt
 
-
 messages=[
-    ChatMessage(role="system", content="You are a helpful assistant."),
-    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
 ]
 prompt = build_llama2_prompt(messages)
 ```
@@ -64,12 +62,11 @@ Example Models:
 
 
 ```python
-from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_vicuna_prompt
 
 messages=[
-    ChatMessage(role="system", content="You are a helpful assistant."),
-    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
 ]
 prompt = build_vicuna_prompt(messages)
 ```
@@ -84,12 +81,11 @@ Example Models:
 ### StarChat
 
 ```python
-from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_chatml_starchat_prompt
 
 messages=[
-    ChatMessage(role="system", content="You are a helpful assistant."),
-    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
 ]
 prompt = build_chatml_starchat_prompt(messages)
 ```
@@ -97,12 +93,11 @@ prompt = build_chatml_starchat_prompt(messages)
 ### Falcon
 
 ```python
-from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_chatml_falcon_prompt
 
 messages=[
-    ChatMessage(role="system", content="You are a helpful assistant."),
-    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
 ]
 prompt = build_chatml_falcon_prompt(messages)
 ```
@@ -116,12 +111,11 @@ Example Models:
 * [WizardLM/WizardLM-13B-V1.2](https://huggingface.co/WizardLM/WizardLM-13B-V1.2)
 
 ```python
-from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_wizardlm_prompt
 
 messages=[
-    ChatMessage(role="system", content="You are a helpful assistant."),
-    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
 ]
 prompt = build_wizardlm_prompt(messages)
 ```
@@ -131,12 +125,11 @@ prompt = build_wizardlm_prompt(messages)
 Creates StableBeluga2 prompt for a chat conversation. If a `Message` with an unsupported `role` is passed, an error will be thrown. [Reference](https://huggingface.co/stabilityai/StableBeluga2)
 
 ```python
-from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_stablebeluga_prompt
 
 messages=[
-    ChatMessage(role="system", content="You are a helpful assistant."),
-    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
 ]
 prompt = build_stablebeluga_prompt(messages)
 ```
@@ -150,12 +143,11 @@ Example Models:
 * [OpenAssistant/llama2-13b-orca-8k-3319](https://huggingface.co/OpenAssistant/llama2-13b-orca-8k-33192)
 
 ```python
-from easyllm.schema.base import ChatMessage
 from easyllm.prompt_utils import build_open_assistant_prompt
 
 messages=[
-    ChatMessage(role="system", content="You are a helpful assistant."),
-    ChatMessage(role="user", content="Explain asynchronous programming in the style of the pirate Blackbeard."),
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
 ]
 prompt = build_open_assistant_prompt(messages)
 ```

--- a/docs/prompt_utils.md
+++ b/docs/prompt_utils.md
@@ -4,16 +4,12 @@ The `prompt_utils`  module contains functions to assist with converting Message'
 
 Supported prompt formats:
 
-- [Prompt utilities](#prompt-utilities)
-  - [Set prompt builder for client](#set-prompt-builder-for-client)
-  - [Llama 2 Chat builder](#llama-2-chat-builder)
-  - [Vicuna Chat builder](#vicuna-chat-builder)
-  - [Hugging Face ChatML builder](#hugging-face-chatml-builder)
-    - [StarChat](#starchat)
-    - [Falcon](#falcon)
-  - [WizardLM Chat builder](#wizardlm-chat-builder)
-  - [StableBeluga2 Chat builder](#stablebeluga2-chat-builder)
-  - [Open Assistant Chat builder](#open-assistant-chat-builder)
+* [Llama 2](#llama-2-chat-builder)
+* [Vicuna](#vicuna-chat-builder)
+* [Hugging Face ChatML](#hugging-face-chatml-builder)
+* [WizardLM](#wizardlm-chat-builder)
+* [StableBeluga2](#stablebeluga2-chat-builder)
+* [Open Assistant](#open-assistant-chat-builder)
 
 Prompt utils are also exporting a mapping dictionary `PROMPT_MAPPING` that maps a model name to a prompt builder function. This can be used to select the correct prompt builder function via an environment variable. 
 

--- a/easyllm/prompt_utils/chatml_hf.py
+++ b/easyllm/prompt_utils/chatml_hf.py
@@ -1,11 +1,11 @@
-from typing import List, Union
+from typing import Dict, List, Union
 
 from easyllm.schema.base import ChatMessage
 
 chatml_falcon_stop_sequences = ["<|endoftext|>"]
 
 
-def build_chatml_falcon_prompt(messages: Union[List[ChatMessage], str]) -> str:
+def build_chatml_falcon_prompt(messages: Union[List[Dict[str,str]], str]) -> str:
     EOS_TOKEN = "<|endoftext|>"
     return build_chatml_hf_prompt(messages, EOS_TOKEN)
 
@@ -13,12 +13,12 @@ def build_chatml_falcon_prompt(messages: Union[List[ChatMessage], str]) -> str:
 chatml_starchat_stop_sequences = ["<|end|>"]
 
 
-def build_chatml_starchat_prompt(messages: Union[List[ChatMessage], str]) -> str:
+def build_chatml_starchat_prompt(messages: Union[List[Dict[str,str]], str]) -> str:
     EOS_TOKEN = "<|end|>"
     return build_chatml_hf_prompt(messages, EOS_TOKEN)
 
 
-def build_chatml_hf_prompt(messages: Union[List[ChatMessage], str], EOS_TOKEN="<|end|>") -> str:
+def build_chatml_hf_prompt(messages: Union[List[Dict[str,str]], str], EOS_TOKEN="<|end|>") -> str:
     """
     Uses HuggingFaceH4 ChatML template used to in Models like, StarChat or Falcon. Uses <|user|>, <|end|>, <|system|>, and <|assistant> tokens. If a Message with an unsupported role is passed, an error will be thrown.
     <|system|>\nYou are a chat bot.<|end|>\n<|user|>\nHello!<|end|>\n<|assistant|>\nHi there!<|end|>\n<|assistant|>
@@ -33,6 +33,8 @@ def build_chatml_hf_prompt(messages: Union[List[ChatMessage], str], EOS_TOKEN="<
 
     if isinstance(messages, str):
         messages = [ChatMessage(content="", role="system"), ChatMessage(content=messages, role="user")]
+    else:
+        messages = [ChatMessage(**message) for message in messages]
 
     for index, message in enumerate(messages):
         if message.role == "user":

--- a/easyllm/prompt_utils/llama2.py
+++ b/easyllm/prompt_utils/llama2.py
@@ -1,11 +1,11 @@
-from typing import List, Union
+from typing import Dict, List, Union
 
 from easyllm.schema.base import ChatMessage
 
 llama2_stop_sequences = ["</s>"]
 
 
-def build_llama2_prompt(messages: Union[List[ChatMessage], str]) -> str:
+def build_llama2_prompt(messages: Union[List[Dict[str, str]], str]) -> str:
     """
     Uses LLama 2 chat tokens (`[INST]`) to create a prompt, learn more in the [Hugging Face Blog on how to prompt Llama 2](https://huggingface.co/blog/llama2#how-to-prompt-llama-2). If a `Message` with an unsupported `role` is passed, an error will be thrown.
     Args:
@@ -18,6 +18,8 @@ def build_llama2_prompt(messages: Union[List[ChatMessage], str]) -> str:
 
     if isinstance(messages, str):
         messages = [ChatMessage(content=messages, role="user")]
+    else:
+        messages = [ChatMessage(**message) for message in messages]
 
     for index, message in enumerate(messages):
         if message.role == "user":

--- a/easyllm/prompt_utils/open_assistant.py
+++ b/easyllm/prompt_utils/open_assistant.py
@@ -1,11 +1,11 @@
-from typing import List, Union
+from typing import Dict, List, Union
 
 from easyllm.schema.base import ChatMessage
 
 open_assistant_stop_sequences = ["</s>"]
 
 
-def build_open_assistant_prompt(messages: Union[List[ChatMessage], str], EOS_TOKEN="<|end|>") -> str:
+def build_open_assistant_prompt(messages: Union[List[Dict[str,str]], str], EOS_TOKEN="<|end|>") -> str:
     """
     Uses Open Assistant ChatML template used to in Models. Uses <|prompter|>, </s>, <|system|>, and <|assistant> tokens. If a Message with an unsupported role is passed, an error will be thrown.
     <|system|>system message</s><|prompter|>user prompt</s><|assistant|>
@@ -21,6 +21,8 @@ def build_open_assistant_prompt(messages: Union[List[ChatMessage], str], EOS_TOK
 
     if isinstance(messages, str):
         messages = [ChatMessage(content="", role="system"), ChatMessage(content=messages, role="user")]
+    else:
+        messages = [ChatMessage(**message) for message in messages]
 
     for index, message in enumerate(messages):
         if message.role == "user":

--- a/easyllm/prompt_utils/stablebeluga.py
+++ b/easyllm/prompt_utils/stablebeluga.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Dict, List, Union
 
 from easyllm.schema.base import ChatMessage
 
@@ -6,7 +6,7 @@ from easyllm.schema.base import ChatMessage
 stablebeluga_stop_sequences = ["</s>"]
 
 
-def build_stablebeluga_prompt(messages: Union[List[ChatMessage], str]) -> str:
+def build_stablebeluga_prompt(messages: Union[List[Dict[str, str]], str]) -> str:
     """
     Builds a stablebeluga prompt for a chat conversation. refrence https://huggingface.co/stabilityai/StableBeluga2 or
 
@@ -23,6 +23,8 @@ def build_stablebeluga_prompt(messages: Union[List[ChatMessage], str]) -> str:
 
     if isinstance(messages, str):
         messages = [ChatMessage(content="", role="system"), ChatMessage(content=messages, role="user")]
+    else:
+        messages = [ChatMessage(**message) for message in messages]
 
     for index, message in enumerate(messages):
         if message.role == "user":

--- a/easyllm/prompt_utils/vicuna.py
+++ b/easyllm/prompt_utils/vicuna.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Dict, List, Union
 
 from easyllm.schema.base import ChatMessage
 
@@ -6,7 +6,7 @@ from easyllm.schema.base import ChatMessage
 vicuna_stop_sequences = ["</s>"]
 
 
-def build_vicuna_prompt(messages: Union[List[ChatMessage], str]) -> str:
+def build_vicuna_prompt(messages: Union[List[Dict[str,str]], str]) -> str:
     """
     Builds a Vicuna prompt for a chat conversation. refrence https://github.com/lm-sys/FastChat/blob/main/docs/vicuna_weights_version.md#prompt-template
 
@@ -23,6 +23,8 @@ def build_vicuna_prompt(messages: Union[List[ChatMessage], str]) -> str:
 
     if isinstance(messages, str):
         messages = [ChatMessage(content="", role="system"), ChatMessage(content=messages, role="user")]
+    else:
+        messages = [ChatMessage(**message) for message in messages]
 
     for index, message in enumerate(messages):
         if message.role == "user":

--- a/easyllm/prompt_utils/wizardlm.py
+++ b/easyllm/prompt_utils/wizardlm.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Dict, List, Union
 
 from easyllm.schema.base import ChatMessage
 
@@ -6,7 +6,7 @@ from easyllm.schema.base import ChatMessage
 wizardlm_stop_sequences = ["</s>"]
 
 
-def build_wizardlm_prompt(messages: Union[List[ChatMessage], str]) -> str:
+def build_wizardlm_prompt(messages: Union[List[Dict[str,str]], str]) -> str:
     """
     Builds a WizardLM prompt for a chat conversation. refrence https://github.com/nlpxucan/WizardLM/blob/4af9edc59e412a49bba51cd1e8cfac2664e909e5/WizardLM/src/infer_wizardlm13b.py#L79
 
@@ -22,6 +22,8 @@ def build_wizardlm_prompt(messages: Union[List[ChatMessage], str]) -> str:
 
     if isinstance(messages, str):
         messages = [ChatMessage(content="", role="system"), ChatMessage(content=messages, role="user")]
+    else:
+        messages = [ChatMessage(**message) for message in messages]
 
     for index, message in enumerate(messages):
         if message.role == "user":

--- a/tests/prompt_utils/test_chatml_hf.py
+++ b/tests/prompt_utils/test_chatml_hf.py
@@ -3,7 +3,6 @@
 import pytest
 
 from easyllm.prompt_utils.chatml_hf import build_chatml_hf_prompt
-from easyllm.schema.base import ChatMessage
 
 
 def test_build_chatml_hf_prompt_single_message():
@@ -15,8 +14,8 @@ def test_build_chatml_hf_prompt_single_message():
 
 def test_build_chatml_hf_prompt_multiple_messages():
     messages = [
-        ChatMessage(content="You are a chat bot.", role="system"),
-        ChatMessage(content="Hello!", role="user"),
+        {"content":"You are a chat bot.", "role":"system"},
+        {"content":"Hello!", "role": "user"},
     ]
     expected_output = "<|system|>\nYou are a chat bot.<|end|>\n<|user|>\nHello!<|end|>\n<|assistant|>"
     result = build_chatml_hf_prompt(messages)
@@ -25,8 +24,8 @@ def test_build_chatml_hf_prompt_multiple_messages():
 
 def test_build_chatml_hf_prompt_function_call():
     messages = [
-        ChatMessage(content="Hello!", role="user"),
-        ChatMessage(content="some_function()", role="function"),
+        {"content":"You are a chat bot.", "role":"system"},
+        {"content":"some_function()", "role": "function"},
     ]
     with pytest.raises(ValueError, match="HF ChatML does not support function calls."):
         build_chatml_hf_prompt(messages)

--- a/tests/prompt_utils/test_llama2.py
+++ b/tests/prompt_utils/test_llama2.py
@@ -1,7 +1,6 @@
 import pytest
 
 from easyllm.prompt_utils.llama2 import build_llama2_prompt
-from easyllm.schema.base import ChatMessage
 
 
 def test_build_llama2_prompt_single_message():
@@ -13,18 +12,19 @@ def test_build_llama2_prompt_single_message():
 
 def test_build_llama2_prompt_multiple_messages():
     messages = [
-        ChatMessage(content="You are a chat bot.", role="system"),
-        ChatMessage(content="Hello!", role="user"),
+        {"content":"You are a chat bot.", "role":"system"},
+        {"content":"Hello!", "role": "user"},
     ]
     expected_output = "<s>[INST] <<SYS>>\nYou are a chat bot.\n<</SYS>>\n\nHello! [/INST]"
     result = build_llama2_prompt(messages)
+    print(f"RESULT: {result}")
     assert result == expected_output
 
 
 def test_build_llama2_prompt_function_call():
     messages = [
-        ChatMessage(content="Hello!", role="user"),
-        ChatMessage(content="some_function()", role="function"),
+        {"content":"You are a chat bot.", "role":"system"},
+        {"content":"some_function()", "role": "function"},
     ]
     with pytest.raises(ValueError, match="Llama 2 does not support function calls."):
         build_llama2_prompt(messages)

--- a/tests/prompt_utils/test_open_assistant.py
+++ b/tests/prompt_utils/test_open_assistant.py
@@ -3,7 +3,6 @@
 import pytest
 
 from easyllm.prompt_utils.open_assistant import build_open_assistant_prompt
-from easyllm.schema.base import ChatMessage
 
 
 def test_build_open_assistant_prompt_single_message():
@@ -15,8 +14,8 @@ def test_build_open_assistant_prompt_single_message():
 
 def test_build_open_assistant_prompt_multiple_messages():
     messages = [
-        ChatMessage(content="You are a chat bot.", role="system"),
-        ChatMessage(content="Hello!", role="user"),
+        {"content":"You are a chat bot.", "role":"system"},
+        {"content":"Hello!", "role": "user"},
     ]
     expected_output = "<|system|>You are a chat bot.</s><|prompter|>Hello!</s><|assistant|>"
     result = build_open_assistant_prompt(messages)
@@ -25,8 +24,8 @@ def test_build_open_assistant_prompt_multiple_messages():
 
 def test_build_open_assistant_prompt_function_call():
     messages = [
-        ChatMessage(content="Hello!", role="user"),
-        ChatMessage(content="some_function()", role="function"),
+        {"content":"You are a chat bot.", "role":"system"},
+        {"content":"some_function()", "role": "function"},
     ]
     with pytest.raises(ValueError, match="Open Assistant does not support function calls."):
         build_open_assistant_prompt(messages)

--- a/tests/prompt_utils/test_stablebeluga.py
+++ b/tests/prompt_utils/test_stablebeluga.py
@@ -3,7 +3,6 @@
 import pytest
 
 from easyllm.prompt_utils.stablebeluga import build_stablebeluga_prompt
-from easyllm.schema.base import ChatMessage
 
 
 def test_build_stablebeluga_prompt_single_message():
@@ -15,8 +14,8 @@ def test_build_stablebeluga_prompt_single_message():
 
 def test_build_stablebeluga_prompt_multiple_messages():
     messages = [
-        ChatMessage(content="You are a chat bot.", role="system"),
-        ChatMessage(content="Hello!", role="user"),
+        {"content":"You are a chat bot.", "role":"system"},
+        {"content":"Hello!", "role": "user"},
     ]
     expected_output = "### System:\nYou are a chat bot.\n\n### User:\nHello!\n\n### Assistant:"
     result = build_stablebeluga_prompt(messages)
@@ -25,8 +24,8 @@ def test_build_stablebeluga_prompt_multiple_messages():
 
 def test_build_stablebeluga_prompt_function_call():
     messages = [
-        ChatMessage(content="Hello!", role="user"),
-        ChatMessage(content="some_function()", role="function"),
+        {"content":"You are a chat bot.", "role":"system"},
+        {"content":"some_function()", "role": "function"},
     ]
     with pytest.raises(ValueError, match="stablebeluga does not support function calls."):
         build_stablebeluga_prompt(messages)

--- a/tests/prompt_utils/test_vicuna.py
+++ b/tests/prompt_utils/test_vicuna.py
@@ -3,7 +3,6 @@
 import pytest
 
 from easyllm.prompt_utils.vicuna import build_vicuna_prompt
-from easyllm.schema.base import ChatMessage
 
 
 def test_build_vicuna_prompt_single_message():
@@ -15,8 +14,8 @@ def test_build_vicuna_prompt_single_message():
 
 def test_build_vicuna_prompt_multiple_messages():
     messages = [
-        ChatMessage(content="You are a chat bot.", role="system"),
-        ChatMessage(content="Hello!", role="user"),
+        {"content":"You are a chat bot.", "role":"system"},
+        {"content":"Hello!", "role": "user"},
     ]
     expected_output = "You are a chat bot.\n\nUSER: Hello!\nASSISTANT: "
     result = build_vicuna_prompt(messages)
@@ -25,8 +24,8 @@ def test_build_vicuna_prompt_multiple_messages():
 
 def test_build_vicuna_prompt_function_call():
     messages = [
-        ChatMessage(content="Hello!", role="user"),
-        ChatMessage(content="some_function()", role="function"),
+        {"content":"You are a chat bot.", "role":"system"},
+        {"content":"some_function()", "role": "function"},
     ]
     with pytest.raises(ValueError, match="Vicuna does not support function calls."):
         build_vicuna_prompt(messages)

--- a/tests/prompt_utils/test_wizardlm.py
+++ b/tests/prompt_utils/test_wizardlm.py
@@ -3,7 +3,6 @@
 import pytest
 
 from easyllm.prompt_utils.wizardlm import build_wizardlm_prompt
-from easyllm.schema.base import ChatMessage
 
 
 def test_build_wizardlm_prompt_single_message():
@@ -15,8 +14,8 @@ def test_build_wizardlm_prompt_single_message():
 
 def test_build_wizardlm_prompt_multiple_messages():
     messages = [
-        ChatMessage(content="You are a chat bot.", role="system"),
-        ChatMessage(content="Hello!", role="user"),
+        {"content":"You are a chat bot.", "role":"system"},
+        {"content":"Hello!", "role": "user"},
     ]
     expected_output = "You are a chat bot. USER: Hello! ASSISTANT: "
     result = build_wizardlm_prompt(messages)
@@ -25,8 +24,8 @@ def test_build_wizardlm_prompt_multiple_messages():
 
 def test_build_wizardlm_prompt_function_call():
     messages = [
-        ChatMessage(content="Hello!", role="user"),
-        ChatMessage(content="some_function()", role="function"),
+        {"content":"You are a chat bot.", "role":"system"},
+        {"content":"some_function()", "role": "function"},
     ]
     with pytest.raises(ValueError, match="WizardLM does not support function calls."):
         build_wizardlm_prompt(messages)


### PR DESCRIPTION
Fixes a bug in the doc examples of the `build_x_prompt()` functions where a list of `dict` messages is expected instead of the list of `ChatMessage` objects.

Without this fix, running examples like:

```python
from easyllm.prompt_utils import build_llama2_prompt

messages=[
    {"role": "system", "content": "You are a helpful assistant."},
    {"role": "user", "content": "Explain asynchronous programming in the style of the pirate Blackbeard."},
]
prompt = build_llama2_prompt(messages)
```

throw the following error:

```
File ~/git/hf/easyllm/easyllm/prompt_utils/llama2.py:23, in build_llama2_prompt(messages)
     20     messages = [ChatMessage(content=messages, role="user")]
     22 for index, message in enumerate(messages):
---> 23     if message.role == "user":
     24         conversation.append(message.content.strip())
     25     elif message.role == "assistant":

AttributeError: 'dict' object has no attribute 'role'
```

The reason this happens is because the prompt builders expect the input to be a list of `ChatMessage` objects that have the `role` and `content` attributes - see e.g. [here](https://github.com/philschmid/easyllm/blob/f734245936d26f54efdb8739a06a0d94f850bfd3/easyllm/prompt_utils/llama2.py#L22-L23)