### PR TITLE
ensure `generated_tokens` is an integer

### DIFF
--- a/easyllm/clients/bedrock.py
+++ b/easyllm/clients/bedrock.py
@@ -193,7 +193,7 @@ You can also use existing prompt builders by importing them from easyllm.prompt_
                     message=ChatMessage(role="assistant", content=res["completion"].strip()),
                     finish_reason=res["stop_reason"],
                 )
-                generated_tokens += len(res["completion"].strip()) / 4
+                generated_tokens += len(res["completion"].strip()) // 4
                 choices.append(parsed)
                 logger.debug(f"Response at index {_i}:\n{parsed}")
             # calculate usage details


### PR DESCRIPTION
The following error is thrown because `generated_tokens` are returned as float and not integer:
```
completion_tokens
  Input should be a valid integer, got a number with a fractional part [type=int_from_float, input_value=37.25, input_type=float]
```