### PR TITLE
Adds support for setting additional client args.

### DIFF
--- a/easyllm/clients/huggingface.py
+++ b/easyllm/clients/huggingface.py
@@ -38,6 +38,7 @@ api_key = (
 )
 api_base = os.environ.get("HUGGINGFACE_API_BASE", None) or "https://api-inference.huggingface.co/models"
 api_version = os.environ.get("HUGGINGFACE_API_VERSION", None) or "2023-07-29"
+client_args = {}
 prompt_builder = os.environ.get("HUGGINGFACE_PROMPT", None)
 stop_sequences = []
 seed = 42
@@ -162,7 +163,7 @@ You can also use existing prompt builders by importing them from easyllm.prompt_
             url = api_base
 
         # create the client
-        client = InferenceClient(url, token=api_key)
+        client = InferenceClient(url, token=api_key, **client_args)
 
         # create stop sequences
         if isinstance(request.stop, list):
@@ -355,7 +356,7 @@ You can also use existing prompt builders by importing them from easyllm.prompt_
             url = api_base
 
         # create the client
-        client = InferenceClient(url, token=api_key)
+        client = InferenceClient(url, token=api_key, **client_args)
 
         # create stop sequences
         if isinstance(request.stop, list):
@@ -471,7 +472,7 @@ class Embedding:
             url = api_base
 
         # create the client
-        client = InferenceClient(url, token=api_key)
+        client = InferenceClient(url, token=api_key, **client_args)
 
         # client is currently not supporting batched request thats why we run sequentially
         emb = []


### PR DESCRIPTION
Adds support for setting additional client args to address issue #44.

Essentially, I added a module-level `client_args` dictionary, similar to `huggingface.api_key` and `.prompt_builder`. A user can put headers, cookies, etc., in there. And the key-value pairs will get unpacked at call-time as additional keyword args.

Note that I left the (implicit) `model` and `token` args untouched. Perhaps it makes sense to do a little work to check whether those are in `client_args` ahead of the call.